### PR TITLE
Add canonical host redirect

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from dotenv import load_dotenv
 import os
-from flask import Flask, render_template
+from flask import Flask, render_template, redirect, request
 
 # Load secrets
 secret_path = Path("/etc/secrets/.env")
@@ -11,6 +11,13 @@ else:                            # Local dev falls back to .env in repo root
     load_dotenv()
 
 app = Flask(__name__)
+
+
+@app.before_request
+def enforce_primary_domain():
+    if request.host and request.host.endswith("zedgerapp.com"):
+        url = request.url.replace("zedgerapp.com", "zedger.app")
+        return redirect(url, code=301)
 
 @app.route("/")
 def index():


### PR DESCRIPTION
## Summary
- redirect old zedgerapp.com domain to zedger.app

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684e25816308832b94ffdd237d26bc74